### PR TITLE
Callback with correct exception when using user-auth-protected keys

### DIFF
--- a/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
@@ -4,7 +4,8 @@ import android.content.Context
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import android.util.Base64
-import com.uport.sdk.signer.encryption.KeyProtection
+import com.uport.sdk.signer.encryption.KeyProtection.Level.SIMPLE
+import com.uport.sdk.signer.testutil.ensureSeedIsImportedInTargetContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -40,7 +41,7 @@ class HDSignerTests {
     fun testSeedCreationAndUsage() {
         val latch = CountDownLatch(1)
 
-        UportHDSigner().createHDSeed(context, KeyProtection.Level.SIMPLE) { err, rootAddress, pubKey ->
+        UportHDSigner().createHDSeed(context, SIMPLE) { err, rootAddress, pubKey ->
 
             assertNull(err)
 
@@ -65,7 +66,7 @@ class HDSignerTests {
         val referencePublicKey = "BFcWkA3uvBb9nSyJmk5rJgx69UtlGN0zwDiNx5TcVmENEUcvF2V26GYP9/3HNE/7vquemm45hDYEqr1/Nph9aIE="
 
         val latch = CountDownLatch(1)
-        UportHDSigner().importHDSeed(context, KeyProtection.Level.SIMPLE, referenceSeedPhrase) { err, address, pubKey ->
+        UportHDSigner().importHDSeed(context, SIMPLE, referenceSeedPhrase) { err, address, pubKey ->
 
             assertNull(err)
 
@@ -107,12 +108,12 @@ class HDSignerTests {
     @Test
     fun testSeedImportAndUsage() {
         val referenceSeedPhrase = "vessel ladder alter error federal sibling chat ability sun glass valve picture"
-        val referenceRootAddress = "0x794adde0672914159c1b77dd06d047904fe96ac8"
+        val referenceRootAddress = ensureSeedIsImportedInTargetContext(referenceSeedPhrase)
         val referenceSignature = "lnEso6Io2pJvlC6sWDLRkvxvpXqcUpZpvr4sdpHcTGA66Y1zher8KlrnWzQ2tt_lpxpx2YYdbfdtkfVmwjex2Q".decodeJose(28)
 
         val referencePayload = Base64.encodeToString("Hello world".toByteArray(), Base64.DEFAULT)
 
-        ensureSeedIsImported(referenceSeedPhrase)
+
 
         val latch = CountDownLatch(1)
 
@@ -130,9 +131,7 @@ class HDSignerTests {
     @Test
     fun checkShowSeed() {
         val referenceSeedPhrase = "idle giraffe soldier dignity angle tiger false finish busy glow ramp frog"
-        val referenceRootAddress = "0xd2bf228f4bf45a9a3d2247d27235e4c07ff0c275"
-
-        ensureSeedIsImported(referenceSeedPhrase)
+        val referenceRootAddress = ensureSeedIsImportedInTargetContext(referenceSeedPhrase)
 
         //check that retrieving it yields the same phrase
         val latch = CountDownLatch(1)
@@ -144,14 +143,6 @@ class HDSignerTests {
         latch.await()
     }
 
-    private fun ensureSeedIsImported(phrase: String) {
-        //ensure seed is imported
-        val latch = CountDownLatch(1)
-        UportHDSigner().importHDSeed(context, KeyProtection.Level.SIMPLE, phrase) { err, _, _ ->
-            assertNull(err)
-            latch.countDown()
-        }
-        latch.await()
-    }
+
 
 }

--- a/signer/src/androidTest/java/com/uport/sdk/signer/UserInteractionContextTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/UserInteractionContextTests.kt
@@ -1,0 +1,114 @@
+package com.uport.sdk.signer
+
+import android.support.test.InstrumentationRegistry
+import android.util.Base64
+import com.uport.sdk.signer.UportSigner.Companion.ERR_ACTIVITY_DOES_NOT_EXIST
+import com.uport.sdk.signer.encryption.KeyProtection
+import com.uport.sdk.signer.testutil.ensureKeyIsImportedInTargetContext
+import com.uport.sdk.signer.testutil.ensureSeedIsImportedInTargetContext
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.kethereum.bip39.Mnemonic
+import java.security.SecureRandom
+import java.util.concurrent.CountDownLatch
+
+class UserInteractionContextTests {
+
+    private val phrase = Mnemonic.generateMnemonic()
+    private val key = ByteArray(32).apply { SecureRandom().nextBytes(this) }
+
+    private val context = InstrumentationRegistry.getTargetContext()
+    //import a key that needs user authentication
+    private val seedHandle = ensureSeedIsImportedInTargetContext(phrase, KeyProtection.Level.PROMPT)
+    private val keyHandle = ensureKeyIsImportedInTargetContext(key, KeyProtection.Level.PROMPT)
+
+    @Test
+    fun shouldThrowOnShowSeedWhenUsingActivityDependentKey() {
+
+        val latch = CountDownLatch(1)
+        UportHDSigner().showHDSeed(context, seedHandle, "this is shown to the user") { err, _ ->
+
+            assertNotNull(err!!)
+            assertTrue(err.message?.contains(ERR_ACTIVITY_DOES_NOT_EXIST) ?: false)
+
+            latch.countDown()
+        }
+
+        latch.await()
+    }
+
+    @Test
+    fun shouldThrowOnSignJwtWhenUsingActivityDependentKey() {
+
+        val somePayloadData = "payload to be signed".toByteArray()
+        val payload = Base64.encodeToString(somePayloadData, Base64.NO_WRAP)
+
+        val latch = CountDownLatch(1)
+        UportHDSigner().signJwtBundle(context, seedHandle, UportHDSigner.UPORT_ROOT_DERIVATION_PATH, payload, "this is shown to the user") { err, _ ->
+
+            assertNotNull(err!!)
+            assertTrue(err.message?.contains(ERR_ACTIVITY_DOES_NOT_EXIST) ?: false)
+
+            latch.countDown()
+        }
+
+        latch.await()
+    }
+
+    @Test
+    fun shouldThrowOnSignTxWhenUsingActivityDependentKey() {
+
+        val somePayloadData = "payload to be signed".toByteArray()
+        val payload = Base64.encodeToString(somePayloadData, Base64.NO_WRAP)
+
+        val latch = CountDownLatch(1)
+        UportHDSigner().signTransaction(context, seedHandle, UportHDSigner.UPORT_ROOT_DERIVATION_PATH, payload, "this is shown to the user") { err, _ ->
+
+            assertNotNull(err!!)
+            assertTrue(err.message?.contains(ERR_ACTIVITY_DOES_NOT_EXIST) ?: false)
+
+            latch.countDown()
+        }
+
+        latch.await()
+    }
+
+
+    @Test
+    fun shouldThrowOnSignJwtSimpleWhenUsingActivityDependentKey() {
+
+        val somePayloadData = "payload to be signed".toByteArray()
+        val payload = Base64.encodeToString(somePayloadData, Base64.NO_WRAP)
+
+        val latch = CountDownLatch(1)
+        UportSigner().signJwtBundle(context, keyHandle, payload, "this is shown to the user") { err, _ ->
+
+            assertNotNull(err!!)
+            assertTrue(err.message?.contains(ERR_ACTIVITY_DOES_NOT_EXIST) ?: false)
+
+            latch.countDown()
+        }
+
+        latch.await()
+    }
+
+    @Test
+    fun shouldThrowOnSignTxSimpleWhenUsingActivityDependentKey() {
+
+        val somePayloadData = "payload to be signed".toByteArray()
+        val payload = Base64.encodeToString(somePayloadData, Base64.NO_WRAP)
+
+        val latch = CountDownLatch(1)
+        UportSigner().signTransaction(context, keyHandle, payload, "this is shown to the user") { err, _ ->
+
+            assertNotNull(err!!)
+            assertTrue(err.message?.contains(ERR_ACTIVITY_DOES_NOT_EXIST) ?: false)
+
+            latch.countDown()
+        }
+
+        latch.await()
+    }
+
+}

--- a/signer/src/androidTest/java/com/uport/sdk/signer/testutil/TestDummyActivity.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/testutil/TestDummyActivity.kt
@@ -1,4 +1,4 @@
-package com.uport.sdk.signer
+package com.uport.sdk.signer.testutil
 
 import android.support.v7.app.AppCompatActivity
 

--- a/signer/src/androidTest/java/com/uport/sdk/signer/testutil/TestHelpers.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/testutil/TestHelpers.kt
@@ -1,0 +1,40 @@
+package com.uport.sdk.signer.testutil
+
+import android.support.test.InstrumentationRegistry
+import com.uport.sdk.signer.UportHDSigner
+import com.uport.sdk.signer.UportSigner
+import com.uport.sdk.signer.encryption.KeyProtection
+import org.junit.Assert
+import java.util.concurrent.CountDownLatch
+
+/**
+ * synchronously imports a given seed phrase at the desired protection level
+ */
+fun ensureSeedIsImportedInTargetContext(phrase: String, level: KeyProtection.Level = KeyProtection.Level.SIMPLE): String {
+    val targetContext = InstrumentationRegistry.getTargetContext()
+    val latch = CountDownLatch(1)
+    lateinit var handle : String
+    UportHDSigner().importHDSeed(targetContext, level, phrase) { err, rootAddress, _ ->
+        Assert.assertNull(err)
+        handle = rootAddress
+        latch.countDown()
+    }
+    latch.await()
+    return handle
+}
+
+/**
+ * synchronously imports a given private key at the desired protection level
+ */
+fun ensureKeyIsImportedInTargetContext(key: ByteArray, level: KeyProtection.Level = KeyProtection.Level.SIMPLE): String {
+    val targetContext = InstrumentationRegistry.getTargetContext()
+    val latch = CountDownLatch(1)
+    lateinit var handle : String
+    UportSigner().saveKey(targetContext, level, key) { err, rootAddress, _ ->
+        Assert.assertNull(err)
+        handle = rootAddress
+        latch.countDown()
+    }
+    latch.await()
+    return handle
+}

--- a/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
@@ -252,7 +252,7 @@ class UportHDSigner : UportSigner() {
 
         encryptionLayer.decrypt(context, prompt, encryptedEntropy) { err, entropyBuff ->
             if (err != null) {
-                return@decrypt callback(storageError, "")
+                return@decrypt callback(err, "")
             }
 
             try {


### PR DESCRIPTION
### What's here
This is a bugfix for #5 along with a bunch of new tests that check for the bug scenario.

### The fix
`UportHDSigner.showHDSeed()` called back with the wrong exception when a user-authenticated key was being used with an Application context instead of an Activity context.
Whenever keys/seeds require user-authentication, they need to be invoked from a user-visible context, which is based on an Activity.

### Testing
I added a bunch of tests for this scenario in `UserInteractionContextTests.kt`
They need to be run on an android device.
You can run all tests by calling `./gradlew cC` with an android/emulator connected