### PR TITLE
add option to delete keys and seeds

### DIFF
--- a/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import android.util.Base64
+import junit.framework.Assert.assertFalse
 import com.uport.sdk.signer.encryption.KeyProtection
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -144,14 +145,34 @@ class HDSignerTests {
         latch.await()
     }
 
-    private fun ensureSeedIsImported(phrase: String) {
+    @Test
+    fun testDeleteSeed() {
+        val tested = UportHDSigner()
+
+        val referencePhrase = "vessel ladder alter error federal sibling chat ability sun glass valve picture"
+        val refRoot = ensureSeedIsImported(referencePhrase)
+
+        assertTrue(tested.allHDRoots(context).contains(refRoot))
+
+        tested.deleteSeed(context, refRoot)
+
+        assertFalse(tested.allHDRoots(context).contains(refRoot))
+    }
+
+
+    private fun ensureSeedIsImported(phrase: String) : String {
+
+        var ref = ""
         //ensure seed is imported
         val latch = CountDownLatch(1)
-        UportHDSigner().importHDSeed(context, KeyProtection.Level.SIMPLE, phrase) { err, _, _ ->
+        UportHDSigner().importHDSeed(context, KeyProtection.Level.SIMPLE, phrase) { err, rootAddr, _ ->
             assertNull(err)
+            ref = rootAddr
             latch.countDown()
         }
         latch.await()
+
+        return ref
     }
 
 }

--- a/signer/src/androidTest/java/com/uport/sdk/signer/SignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/SignerTests.kt
@@ -5,9 +5,7 @@ import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import android.util.Base64
 import com.uport.sdk.signer.encryption.KeyProtection
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -302,6 +300,33 @@ class SignerTests {
 
         assertTrue(storedAddressList.containsAll(addresses))
 
+    }
+
+    @Test
+    fun testDeleteKey() {
+        val referencePrivateKey = Hex.decode("5047c789919e943c559d8c134091d47b4642122ba0111dfa842ef6edefb48f38")
+
+        val tested = UportSigner()
+
+        var keyHandle = ""
+
+        var latch = CountDownLatch(1)
+        tested.saveKey(context, KeyProtection.Level.SIMPLE, referencePrivateKey) { err, addr, _ ->
+            assertNull(err)
+            keyHandle = addr
+            latch.countDown()
+        }
+        latch.await()
+
+        tested.deleteKey(context, keyHandle)
+
+        latch = CountDownLatch(1)
+        tested.allAddresses(context) { all ->
+            assertFalse(all.contains(keyHandle))
+            latch.countDown()
+        }
+
+        latch.await()
     }
 }
 

--- a/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
@@ -92,6 +92,19 @@ class UportHDSigner : UportSigner() {
         }
     }
 
+    /**
+     * Deletes a seed from storage.
+     */
+    fun deleteSeed(context: Context, label: String) {
+        val prefs = context.getSharedPreferences(ETH_ENCRYPTED_STORAGE, MODE_PRIVATE)
+        prefs.edit()
+                //store encrypted privatekey
+                .remove(asSeedLabel(label))
+                //mark the key as encrypted with provided security level
+                .remove(asLevelLabel(label))
+                .apply()
+    }
+
 
     /**
      * Signs a transaction bundle using a key derived from a previously imported/created seed.

--- a/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
@@ -102,14 +102,17 @@ open class UportSigner {
         }
     }
 
-//    private fun deleteKey(context: Context, address: String) {
-//        val prefs = context.getSharedPreferences(ETH_ENCRYPTED_STORAGE, MODE_PRIVATE)
-//        val label = asAddressLabel(address)
-//        prefs.edit()
-//                .remove(label)
-//                .remove(asLevelLabel(label))
-//                .apply()
-//    }
+    /**
+     * deletes a key from storage
+     */
+    fun deleteKey(context: Context, address: String) {
+        val prefs = context.getSharedPreferences(ETH_ENCRYPTED_STORAGE, MODE_PRIVATE)
+        val label = asAddressLabel(address)
+        prefs.edit()
+                .remove(label)
+                .remove(asLevelLabel(label))
+                .apply()
+    }
 
     /**
      * Signs a transaction bundle using the private key that generated the given address.

--- a/signer/src/test/java/com/uport/sdk/signer/crypto/bip32/ExtendedKeyTest.kt
+++ b/signer/src/test/java/com/uport/sdk/signer/crypto/bip32/ExtendedKeyTest.kt
@@ -138,4 +138,4 @@ class ExtendedKeyTest {
 
 }
 
-internal fun ExtendedKey.asPublicOnly(): ExtendedKey = this.copy(keyPair = ECKeyPair(BigInteger.ZERO, this.getKeyPair().publicKey))
+internal fun ExtendedKey.asPublicOnly(): ExtendedKey = this.copy(keyPair = ECKeyPair(BigInteger.ZERO, this.keyPair.publicKey))


### PR DESCRIPTION
### What's here

The signer was missing functionality to delete previously created/imported keys/seeds (#8)
This PR contains code to fix that and tests to validate it.

### Testing

run `./gradlew cC` with an emulator/device connected to go through all the instrumented tests, including the new ones.