### PR TITLE
add option to JOSE encode signatures with recovery param included.

### DIFF
--- a/signer/src/main/java/com/uport/sdk/signer/Extensions.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/Extensions.kt
@@ -17,22 +17,34 @@ import java.util.*
 
 
 const val SIG_COMPONENT_SIZE = PRIVATE_KEY_SIZE
+const val SIG_SIZE = SIG_COMPONENT_SIZE * 2
+const val SIG_RECOVERABLE_SIZE = SIG_SIZE + 1
 
 /**
  * Returns the JOSE encoding of the standard signature components (joined by empty string)
  */
-fun SignatureData.getJoseEncoded(): String {
-    val bos = ByteArrayOutputStream()
+fun SignatureData.getJoseEncoded(recoverable: Boolean = false): String {
+    val size = if (recoverable)
+        SIG_RECOVERABLE_SIZE
+    else
+        SIG_SIZE
+
+    val bos = ByteArrayOutputStream(size)
     bos.write(this.r.toBytesPadded(SIG_COMPONENT_SIZE))
     bos.write(this.s.toBytesPadded(SIG_COMPONENT_SIZE))
+    if (recoverable) {
+        bos.write(byteArrayOf(this.v))
+    }
     return Base64.encodeToString(bos.toByteArray(), Base64.NO_WRAP or Base64.NO_PADDING or Base64.URL_SAFE)
 }
 
-fun String.decodeJose(recoveryParam: Byte = 27): SignatureData = listOf(this)
-        .map { Base64.decode(it, Base64.URL_SAFE) }
-        .map { Arrays.copyOfRange(it, 0, 32) to Arrays.copyOfRange(it, 32, 64) }
-        .map { SignatureData(BigInteger(1, it.first), BigInteger(1, it.second), recoveryParam) }
-        .first()
+fun String.decodeJose(recoveryParam: Byte = 27): SignatureData {
+    val bytes = Base64.decode(this, Base64.URL_SAFE)
+    val rBytes = Arrays.copyOfRange(bytes, 0, SIG_COMPONENT_SIZE)
+    val sBytes = Arrays.copyOfRange(bytes, SIG_COMPONENT_SIZE, SIG_SIZE)
+    val v = if (bytes.size > SIG_SIZE) bytes[SIG_SIZE] else recoveryParam
+    return SignatureData(BigInteger(1, rBytes), BigInteger(1, sBytes), v)
+}
 
 /**
  * Returns the DER encoding of the standard signature components


### PR DESCRIPTION
This fixes #11 

This is useful for creating ES256K-R JWTs.