### PR TITLE
[Bugfix] signer returns null errors when given bad input

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         espresso_version = "3.0.2"
         junit_version = "4.12"
         mockk_version = "1.9.3"
-        assertk_version = "0.12"
+        assertk_version = "0.13"
         detekt_version = "1.0.0-RC14"
 
         spongycastle_version = "1.58.0.0"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         kotlin_version = "1.3.31"
-        android_tools_version = '3.4.0'
+        android_tools_version = '3.4.1'
         coroutines_version = "1.2.1"
 
         build_tools_version = "28.0.3"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,18 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-VERSION_NAME=0.0.1
-VERSION_CODE=1
-GROUP=me.uport
-
-POM_DESCRIPTION=A library set for the uport android SDK
-POM_URL=https://github.com/uport-project/uport-android-signer
-POM_SCM_URL=https://github.com/uport-project/uport-android-signer
-POM_SCM_CONNECTION=scm:git@github.com:uport-project/uport-android-signer.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:uport-project/uport-android-signer.git
-POM_LICENCE_NAME=The Apache Software License, Version 2.0
-POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
-POM_LICENCE_DIST=repo
-POM_DEVELOPER_ID=mirceanis
-POM_DEVELOPER_NAME=Mircea Nistor

--- a/signer/build.gradle
+++ b/signer/build.gradle
@@ -59,6 +59,8 @@ dependencies {
 
     androidTestImplementation "com.android.support.test:runner:$test_runner_version"
     androidTestImplementation "com.android.support.test:rules:$test_rules_version"
+    androidTestImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
+    androidTestImplementation "com.github.uport-project.kotlin-common:test-helpers:$kotlin_common_version"
 
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
     testImplementation "com.github.komputing.KEthereum:bip44:$kethereum_version"

--- a/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
@@ -3,7 +3,7 @@ package com.uport.sdk.signer
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 import android.support.test.InstrumentationRegistry
-import assertk.assert
+import assertk.assertThat
 import assertk.assertions.isNotNull
 import com.uport.sdk.signer.encryption.KeyProtection.Level.SIMPLE
 import com.uport.sdk.signer.testutil.ensureKeyIsImportedInTargetContext
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit
 class HDSignerTests {
 
     init {
-        //Kethereum has some provider initialization code that is causing problems if that code is used before any hybrid encryption code
+        //KEthereum has some provider initialization code that is causing problems if that code is used before any hybrid encryption code
         // the failure shows up as "java.lang.AssertionError: expected null, but was:<java.lang.IllegalStateException: Can't generate certificate>"
         //TODO: check back here when that is fixed: https://github.com/walleth/kethereum/issues/22
         Security.addProvider(BouncyCastleProvider())
@@ -174,9 +174,9 @@ class HDSignerTests {
                 "m/",
                 "this is not base 64 !@#$%",
                 ""
-        ) { err, sig ->
+        ) { err, _ ->
             // should fail when decoding bad base64
-            assert(err).isNotNull()
+            assertThat(err).isNotNull()
             latch.countDown()
         }
         latch.await()
@@ -191,9 +191,9 @@ class HDSignerTests {
                 ref,
                 "this is not base 64 !@#$%",
                 ""
-        ) { err, sig ->
+        ) { err, _ ->
             // should fail when decoding bad base64
-            assert(err).isNotNull()
+            assertThat(err).isNotNull()
             latch.countDown()
         }
         latch.await()
@@ -215,7 +215,7 @@ class HDSignerTests {
                 "m/",
                 ""
         ) { err, _, _ ->
-            assert(err).isNotNull()
+            assertThat(err).isNotNull()
             latch.countDown()
         }
         latch.await()

--- a/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
@@ -1,13 +1,17 @@
 package com.uport.sdk.signer
 
 import android.content.Context
+import android.content.Context.MODE_PRIVATE
 import android.support.test.InstrumentationRegistry
+import assertk.assert
+import assertk.assertions.isNotNull
 import com.uport.sdk.signer.encryption.KeyProtection.Level.SIMPLE
+import com.uport.sdk.signer.testutil.ensureKeyIsImportedInTargetContext
 import com.uport.sdk.signer.testutil.ensureSeedIsImportedInTargetContext
 import me.uport.sdk.core.decodeBase64
-import me.uport.sdk.signer.decodeJose
 import me.uport.sdk.core.padBase64
 import me.uport.sdk.core.toBase64
+import me.uport.sdk.signer.decodeJose
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -19,6 +23,7 @@ import org.kethereum.bip39.model.MnemonicWords
 import org.kethereum.bip39.toSeed
 import org.kethereum.extensions.hexToBigInteger
 import org.spongycastle.jce.provider.BouncyCastleProvider
+import org.walleth.khex.hexToByteArray
 import java.security.Security
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -156,6 +161,65 @@ class HDSignerTests {
         tested.deleteSeed(context, refRoot)
 
         assertFalse(tested.allHDRoots(context).contains(refRoot))
+    }
+
+    @Test
+    fun returns_error_when_HD_signing_invalid_jwt_bundle() {
+        val referencePhrase = "vessel ladder alter error federal sibling chat ability sun glass valve picture"
+        val refRoot = ensureSeedIsImportedInTargetContext(referencePhrase)
+        val latch = CountDownLatch(1)
+        UportHDSigner().signJwtBundle(
+                context,
+                refRoot,
+                "m/",
+                "this is not base 64 !@#$%",
+                ""
+        ) { err, sig ->
+            // should fail when decoding bad base64
+            assert(err).isNotNull()
+            latch.countDown()
+        }
+        latch.await()
+    }
+
+    @Test
+    fun returns_error_when_signing_invalid_jwt_bundle() {
+        val ref = ensureKeyIsImportedInTargetContext("5047c789919e943c559d8c134091d47b4642122ba0111dfa842ef6edefb48f38".hexToByteArray())
+        val latch = CountDownLatch(1)
+        UportSigner().signJwtBundle(
+                context,
+                ref,
+                "this is not base 64 !@#$%",
+                ""
+        ) { err, sig ->
+            // should fail when decoding bad base64
+            assert(err).isNotNull()
+            latch.countDown()
+        }
+        latch.await()
+    }
+
+    @Test
+    fun returns_error_when_computing_address_for_invalid_seed() {
+
+        val referencePhrase = "vessel ladder alter error federal sibling chat ability sun glass valve picture"
+        val seedHandle = ensureSeedIsImportedInTargetContext(referencePhrase)
+
+        val prefs = InstrumentationRegistry.getTargetContext().getSharedPreferences("eth_signer_store", MODE_PRIVATE)
+        prefs.edit().putString("seed-$seedHandle", "corrupted seed data").apply()
+
+        val latch = CountDownLatch(1)
+        UportHDSigner().computeAddressForPath(
+                context,
+                seedHandle,
+                "m/",
+                ""
+        ) { err, _, _ ->
+            assert(err).isNotNull()
+            latch.countDown()
+        }
+        latch.await()
+
     }
 
 }

--- a/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
@@ -93,8 +93,8 @@ class UportHDSigner : UportSigner() {
 
                 return@storeEncryptedPayload callback(null, address, publicKeyString)
             }
-        } catch (ex: Exception) {
-            return callback(ex, "", "")
+        } catch (seedImprotError: Exception) {
+            return callback(seedImprotError, "", "")
         }
     }
 
@@ -138,10 +138,10 @@ class UportHDSigner : UportSigner() {
             return callback(storageError, EMPTY_SIGNATURE_DATA)
         }
 
-        encryptionLayer.decrypt(context, prompt, encryptedEntropy) { err, entropyBuff ->
+        encryptionLayer.decrypt(context, prompt, encryptedEntropy) { decryptError, entropyBuff ->
 
-            if (err != null) {
-                return@decrypt callback(err, EMPTY_SIGNATURE_DATA)
+            if (decryptError != null) {
+                return@decrypt callback(decryptError, EMPTY_SIGNATURE_DATA)
             }
 
             try {
@@ -156,8 +156,8 @@ class UportHDSigner : UportSigner() {
                 val sigData = keyPair.signMessage(txBytes)
                 return@decrypt callback(null, sigData)
 
-            } catch (exception: Exception) {
-                return@decrypt callback(exception, EMPTY_SIGNATURE_DATA)
+            } catch (signError: Exception) {
+                return@decrypt callback(signError, EMPTY_SIGNATURE_DATA)
             }
 
         }
@@ -189,9 +189,9 @@ class UportHDSigner : UportSigner() {
             return callback(storageError, SignatureData())
         }
 
-        encryptionLayer.decrypt(context, prompt, encryptedEntropy) { err, entropyBuff ->
-            if (err != null) {
-                return@decrypt callback(err, SignatureData())
+        encryptionLayer.decrypt(context, prompt, encryptedEntropy) { decryptError, entropyBuff ->
+            if (decryptError != null) {
+                return@decrypt callback(decryptError, SignatureData())
             }
 
             try {
@@ -204,8 +204,8 @@ class UportHDSigner : UportSigner() {
                 val sig = signJwt(payloadBytes, keyPair)
 
                 return@decrypt callback(null, sig)
-            } catch (exception: Exception) {
-                return@decrypt callback(err, SignatureData())
+            } catch (signError: Exception) {
+                return@decrypt callback(signError, SignatureData())
             }
         }
     }
@@ -226,9 +226,9 @@ class UportHDSigner : UportSigner() {
             return callback(storageError, "", "")
         }
 
-        encryptionLayer.decrypt(context, prompt, encryptedEntropy) { err, entropyBuff ->
-            if (err != null) {
-                return@decrypt callback(storageError, "", "")
+        encryptionLayer.decrypt(context, prompt, encryptedEntropy) { decryptError, entropyBuff ->
+            if (decryptError != null) {
+                return@decrypt callback(decryptError, "", "")
             }
 
             try {
@@ -243,8 +243,8 @@ class UportHDSigner : UportSigner() {
 
                 return@decrypt callback(null, address, publicKeyString)
 
-            } catch (exception: Exception) {
-                return@decrypt callback(err, "", "")
+            } catch (derivationError: Exception) {
+                return@decrypt callback(derivationError, "", "")
             }
         }
 
@@ -275,7 +275,7 @@ class UportHDSigner : UportSigner() {
                 val phrase = entropyToMnemonic(entropyBuff, WORDLIST_ENGLISH)
                 return@decrypt callback(null, phrase)
             } catch (exception: Exception) {
-                return@decrypt callback(err, "")
+                return@decrypt callback(exception, "")
             }
         }
     }

--- a/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportHDSigner.kt
@@ -64,8 +64,6 @@ class UportHDSigner : UportSigner() {
     fun importHDSeed(context: Context, level: KeyProtection.Level, phrase: String, callback: (err: Exception?, address: String, pubKey: String) -> Unit) {
 
         try {
-//            val seedBuffer = mnemonicToSeed(phrase)
-
             val entropyBuffer = mnemonicToEntropy(phrase, WORDLIST_ENGLISH)
 
             val extendedRootKey = MnemonicWords(phrase).toKey(UPORT_ROOT_DERIVATION_PATH)
@@ -93,8 +91,8 @@ class UportHDSigner : UportSigner() {
 
                 return@storeEncryptedPayload callback(null, address, publicKeyString)
             }
-        } catch (seedImprotError: Exception) {
-            return callback(seedImprotError, "", "")
+        } catch (seedImportError: Exception) {
+            return callback(seedImportError, "", "")
         }
     }
 

--- a/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
@@ -98,13 +98,13 @@ open class UportSigner {
                 level,
                 label,
                 privateKeyBytes
-        ) { err, _ ->
+        ) { encryptionError, _ ->
 
             //empty memory
             privateKeyBytes.fill(0)
 
-            if (err != null) {
-                return@storeEncryptedPayload callback(err, "", "")
+            if (encryptionError != null) {
+                return@storeEncryptedPayload callback(encryptionError, "", "")
             }
 
             return@storeEncryptedPayload callback(null, address, publicKeyString)
@@ -147,10 +147,10 @@ open class UportSigner {
             return callback(storageError, EMPTY_SIGNATURE_DATA)
         }
 
-        encryptionLayer.decrypt(context, prompt, encryptedPrivateKey) { err, privateKeyBytes ->
+        encryptionLayer.decrypt(context, prompt, encryptedPrivateKey) { decryptionError, privateKeyBytes ->
 
-            if (err != null) {
-                return@decrypt callback(err, EMPTY_SIGNATURE_DATA)
+            if (decryptionError != null) {
+                return@decrypt callback(decryptionError, EMPTY_SIGNATURE_DATA)
             }
 
             try {
@@ -162,8 +162,8 @@ open class UportSigner {
                 val sigData = keyPair.signMessage(txBytes)
                 return@decrypt callback(null, sigData)
 
-            } catch (exception: Exception) {
-                return@decrypt callback(exception, EMPTY_SIGNATURE_DATA)
+            } catch (signError: Exception) {
+                return@decrypt callback(signError, EMPTY_SIGNATURE_DATA)
             }
 
         }
@@ -226,9 +226,9 @@ open class UportSigner {
             return callback(storageError, SignatureData())
         }
 
-        encryptionLayer.decrypt(context, prompt, encryptedPrivateKey) { err, privateKeyBytes ->
-            if (err != null) {
-                return@decrypt callback(err, SignatureData())
+        encryptionLayer.decrypt(context, prompt, encryptedPrivateKey) { decryptionError, privateKeyBytes ->
+            if (decryptionError != null) {
+                return@decrypt callback(decryptionError, SignatureData())
             }
 
             try {
@@ -238,8 +238,8 @@ open class UportSigner {
                 privateKeyBytes.fill(0)
 
                 return@decrypt callback(null, sig)
-            } catch (exception: Exception) {
-                return@decrypt callback(err, SignatureData())
+            } catch (signingError: Exception) {
+                return@decrypt callback(signingError, SignatureData())
             }
         }
     }


### PR DESCRIPTION
### What's here

This fixes [#166180367 ](https://www.pivotaltracker.com/story/show/166180367).
The cause is that in some nested callback scenarios during signing JWT or other key usages, the error returned by the last callback was from one level up, making it always `null`.
This causes problems down the line where the error check passes but the signature is blank.

### Testing

I added some regression tests to validate the bug and then fixed the issue.
They need to be run manually on a device or emulator.
Run `./gradlew test cC --no-parallel` to go through the whole testsuite locally.