### PR TITLE
Fix "IllegalStateException: At least one fingerprint must be enrolled..."

### DIFF
--- a/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
@@ -245,7 +245,7 @@ open class UportSigner {
     }
 
     @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
-    fun signJwt(payloadBytes: ByteArray, keyPair: ECKeyPair) = signMessageHash(payloadBytes.sha256(), keyPair, false)
+    internal fun signJwt(payloadBytes: ByteArray, keyPair: ECKeyPair) = signMessageHash(payloadBytes.sha256(), keyPair, false)
 
     /**
      * Builds a list of all the saved eth addresses (that also have encrypted private keys tracked)

--- a/signer/src/main/java/com/uport/sdk/signer/encryption/KeyProtection.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/encryption/KeyProtection.kt
@@ -42,6 +42,7 @@ abstract class KeyProtection {
         /**
          * unused yet - defaults to [SIMPLE]
          */
+        @Suppress("unused")
         CLOUD
     }
 

--- a/signer/src/main/java/com/uport/sdk/signer/encryption/KeyProtectionFactory.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/encryption/KeyProtectionFactory.kt
@@ -37,21 +37,25 @@ object KeyProtectionFactory {
                 if (KeyProtection.hasSetupFingerprint(context)) {
                     FingerprintAsymmetricProtection()
                 } else {
-                    val sessionTime = if (KeyProtection.hasFingerprintHardware(context)) {
-                        0 // pop keyguard with 0 second authentication window (practically for every use)
+
+                    // pop keyguard with 0 second authentication window (practically for every use)
+                    val sessionTime = 0
 
                         /**
                          * reason for this behavior:
                          *
-                         * on devices that have fingerprint hardware but haven't setup fingerprints
+                         * On devices that have fingerprint hardware but haven't setup fingerprints
                          * an IllegalBlockSizeException is thrown if the requested session time is "-1"
                          * with the cause being KeyStoreException("Key user not authenticated")
                          *
+                         * Also, on some devices that DO NOT HAVE fingerprint hardware, using a "-1"
+                         * session time would throw
+                         *  > java.lang.IllegalStateException: At least one fingerprint must be enrolled
+                         *  > to create keys requiring user authentication for every use"
+                         *
                          * Therefore, we emulate this by a 0 second authentication window
                          */
-                    } else {
-                        -1 // pop keyguard for every use
-                    }
+
                     KeyguardAsymmetricProtection(sessionTime)
                 }
             }


### PR DESCRIPTION
### What's here

This fixes the error:
> java.lang.IllegalStateException: At least one fingerprint must be enrolled to create keys requiring user authentication for every use

that was thrown when creating a key/seed with `KeyProtection.Level.PROMPT` on **some** devices without fingerprint sensor.

### Root cause

On devices without a fingerprint sensor or those that don't have fingerprints enrolled the default behavior is to fallback to a KeyGuard when `PROMPT` is used for key protection.
The AndroidKeyStore API permits the use of a parameter to specify the time window of authentication; the number of seconds during which the keyguard is not prompted again.
When this param is set to `-1` that means prompt every time the key is used, but this is buggy on some devices, throwing the above mentioned error.

The fix is to use a sessionTime of `0` whenever a KeyGuard protection is used as fallback instead of Fingerprint.

### Testing

Manual testing is required.
- Build the demoapp using v0.3.1 of the signer ( commit d32485fd0eb693d0af865ee2039269073d1921ed )
- Use the app on a device with no fingerprint sensor and try to use the Fingerprint flow.
- observe the failure when attempting to create a seed
- build the demoapp using the fix on this branch
- observe that when following the Fingerprint flow on that device, a Keyguard is prompted


This has been reported on Huawei P8 Light 2015 and Orange Rise 31
Note that the bug only manifests on some devices.