### PR TITLE
[bugfix] using Pattern to unlock a seed fails randomly with "User not authenticated"

### DIFF
--- a/signer/src/main/java/com/uport/sdk/signer/encryption/KeyProtectionFactory.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/encryption/KeyProtectionFactory.kt
@@ -38,8 +38,8 @@ object KeyProtectionFactory {
                     FingerprintAsymmetricProtection()
                 } else {
 
-                    // pop keyguard with 0 second authentication window (practically for every use)
-                    val sessionTime = 0
+                    // pop keyguard with 1 second authentication window
+                    val sessionTime = 1
 
                         /**
                          * reason for this behavior:
@@ -53,7 +53,8 @@ object KeyProtectionFactory {
                          *  > java.lang.IllegalStateException: At least one fingerprint must be enrolled
                          *  > to create keys requiring user authentication for every use"
                          *
-                         * Therefore, we emulate this by a 0 second authentication window
+                         * Therefore, we need to emulate this by a 1 second authentication window
+                         * which should be enough to perform the decryption.
                          */
 
                     KeyguardAsymmetricProtection(sessionTime)


### PR DESCRIPTION
### Steps to reproduce

1. Setup a device's security to use Pattern keyguard.
2. Run the demoapp following the `fingerprint` flow
3. create HD seed
4. sign something
5. pattern keyguard is shown
6. input correct pattern

### Expected behavior:

* keyguard is closed and the signed string is shown every time step 4. is done 

### Actual behavior

* keyguard is closed but the expected action does not work everytime
Instead, an error is thrown: "User not authenticated"
* usually if step 4. is retried, the flow works correctly


### Cause

This appears to be caused by the "emulated prompt every time" behavior done through using a `0` second window of authorization.
This causes the app to randomly throw this error, mostly when the device is slow, so it's probably overshooting some internal authorization window.

The fix is to expand the authorization window to 1 second with the acceptable risk that if another signature is requested sufficiently fast by the app, it will go through without prompting.

### Testing

This is reproducible on an android emulator with API level 23. Manual testing is required.