### PR TITLE
refactor: bump dependencies and adapt to new imports and APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
-        kotlin_version = "1.3.41"
-        android_tools_version = '3.4.1'
-        coroutines_version = "1.2.2"
+        kotlin_version = "1.3.50"
+        android_tools_version = '3.5.0'
+        coroutines_version = "1.3.0"
 
         build_tools_version = "28.0.3"
 
@@ -23,8 +23,9 @@ buildscript {
         detekt_version = "1.0.0-RC14"
 
         spongycastle_version = "1.58.0.0"
-        kethereum_version = "0.75.1"
-        kotlin_common_version = "0.1.2"
+        kethereum_version = "0.76.1"
+        khex_version = "1.0.0-RC3"
+        kotlin_common_version = "0.3.0"
         jacoco_version = "0.8.4"
 
         current_release_version = "0.3.3"
@@ -111,11 +112,6 @@ subprojects { subproject ->
 
         if (subproject.plugins.hasPlugin("com.android.application") || subproject.plugins.hasPlugin("com.android.library")) {
             subproject.android {
-                packagingOptions {
-                    exclude "META-INF/main.kotlin_module"
-                    exclude "META-INF/atomicfu.kotlin_module"
-                }
-
                 compileOptions {
                     sourceCompatibility JavaVersion.VERSION_1_8
                     targetCompatibility JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         spongycastle_version = "1.58.0.0"
         kethereum_version = "0.76.1"
         khex_version = "1.0.0-RC3"
-        kotlin_common_version = "0.3.0"
+        kotlin_common_version = "0.3.1"
         jacoco_version = "0.8.4"
 
         current_release_version = "0.3.3"

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -45,6 +45,14 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
+    packagingOptions {
+        pickFirst "META-INF/main.kotlin_module"
+        pickFirst "META-INF/atomicfu.kotlin_module"
+        pickFirst "META-INF/kotlinx-io.kotlin_module"
+        pickFirst "META-INF/extensions.kotlin_module"
+        pickFirst "META-INF/core.kotlin_module"
+    }
 }
 
 dependencies {
@@ -54,6 +62,12 @@ dependencies {
 
 //    implementation "com.github.uport-project:uport-android-signer:$current_release_version"
     implementation project(":signer")
+
+    //used to generate and encode seeds to demonstrate importing them
+    implementation "com.github.uport-project.kotlin-common:core:$kotlin_common_version"
+    implementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
+    implementation "com.github.komputing.KEthereum:bip39:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:bip39_wordlist_en:$kethereum_version"
 
     implementation "com.android.support.constraint:constraint-layout:$constraint_layout_version"
 

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -38,7 +38,6 @@ android {
             minifyEnabled true
             shrinkResources true
             zipAlignEnabled true
-            useProguard true
 
             signingConfig signingConfigs.debug
 

--- a/demoapp/src/main/java/me/uport/signer/demo/CreateKeysActivity.kt
+++ b/demoapp/src/main/java/me/uport/signer/demo/CreateKeysActivity.kt
@@ -10,7 +10,7 @@ import kotlinx.android.synthetic.main.content_create_keys.*
 import me.uport.sdk.core.decodeBase64
 import org.kethereum.bip39.generateMnemonic
 import org.kethereum.bip39.wordlists.WORDLIST_ENGLISH
-import org.walleth.khex.toHexString
+import org.komputing.khex.extensions.toHexString
 
 
 class CreateKeysActivity : AppCompatActivity() {
@@ -26,9 +26,9 @@ class CreateKeysActivity : AppCompatActivity() {
             mnemonicPhraseField.setText(phrase)
         }
 
-        importButton.setOnClickListener { _ ->
+        importButton.setOnClickListener { view ->
             val phrase = mnemonicPhraseField.text.toString()
-            UportHDSigner().importHDSeed(this, KeyProtection.Level.SIMPLE, phrase) { err, address, publicKey ->
+            UportHDSigner().importHDSeed(view.context, KeyProtection.Level.SIMPLE, phrase) { err, address, publicKey ->
                 errorField.text = "error: ${err.toString()}"
                 publicKeyField.text = "publicKey: ${publicKey.decodeBase64().toHexString()}"
                 addressField.text = "address: $address"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,5 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 kotlin.code.style=official
 kotlin.incremental=true
+
+android.enableR8=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip

--- a/signer/build.gradle
+++ b/signer/build.gradle
@@ -1,3 +1,5 @@
+import java.time.temporal.TemporalAdjusters
+
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 apply plugin: "com.github.dcendents.android-maven"
@@ -39,11 +41,14 @@ android {
 //        execution "ANDROID_TEST_ORCHESTRATOR"
     }
 
-}
+    packagingOptions {
+        exclude "META-INF/main.kotlin_module"
+        exclude "META-INF/atomicfu.kotlin_module"
+        exclude "META-INF/kotlinx-io.kotlin_module"
+        exclude "META-INF/extensions.kotlin_module"
+        exclude "META-INF/core.kotlin_module"
+    }
 
-//XXX: this is needed until https://github.com/komputing/KEthereum/issues/65 is fixed
-configurations.all {
-    exclude group: "com.github.walleth"
 }
 
 dependencies {
@@ -51,17 +56,26 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "com.android.support:appcompat-v7:$support_lib_version"
 
-    api "com.github.komputing.KEthereum:bip39:$kethereum_version"
-    api "com.github.komputing.KEthereum:bip32:$kethereum_version"
-    api "com.github.komputing.KEthereum:bip39_wordlist_en:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:bip39:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:bip32:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:bip39_wordlist_en:$kethereum_version"
+
+    api "com.github.komputing.KEthereum:model:$kethereum_version"
+
+    implementation "com.github.komputing.KEthereum:crypto:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:extensions:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:hashes:$kethereum_version"
     api "com.github.uport-project.kotlin-common:signer-common:$kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:core:$kotlin_common_version"
     implementation "com.madgag.spongycastle:prov:$spongycastle_version"
 
     androidTestImplementation "com.android.support.test:runner:$test_runner_version"
     androidTestImplementation "com.android.support.test:rules:$test_rules_version"
     androidTestImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
     androidTestImplementation "com.github.uport-project.kotlin-common:test-helpers:$kotlin_common_version"
+    androidTestImplementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
 
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
     testImplementation "com.github.komputing.KEthereum:bip44:$kethereum_version"
+    testImplementation "com.github.komputing.KHex:extensions-jvm:$khex_version"
 }

--- a/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/HDSignerTests.kt
@@ -22,8 +22,8 @@ import org.kethereum.bip32.toKey
 import org.kethereum.bip39.model.MnemonicWords
 import org.kethereum.bip39.toSeed
 import org.kethereum.extensions.hexToBigInteger
+import org.komputing.khex.extensions.hexToByteArray
 import org.spongycastle.jce.provider.BouncyCastleProvider
-import org.walleth.khex.hexToByteArray
 import java.security.Security
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit

--- a/signer/src/androidTest/java/com/uport/sdk/signer/SignerTests.kt
+++ b/signer/src/androidTest/java/com/uport/sdk/signer/SignerTests.kt
@@ -20,9 +20,9 @@ import org.kethereum.crypto.signMessage
 import org.kethereum.crypto.toECKeyPair
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.model.PrivateKey
+import org.komputing.khex.extensions.hexToByteArray
+import org.komputing.khex.extensions.toNoPrefixHexString
 import org.spongycastle.util.encoders.Hex
-import org.walleth.khex.hexToByteArray
-import org.walleth.khex.toNoPrefixHexString
 import java.math.BigInteger
 import java.util.*
 import java.util.concurrent.CountDownLatch
@@ -185,6 +185,7 @@ class SignerTests {
         assertEquals(referenceSignature, sigData)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testJwtDer() {
         val referencePrivateKey = "5047c789919e943c559d8c134091d47b4642122ba0111dfa842ef6edefb48f38"

--- a/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
+++ b/signer/src/main/java/com/uport/sdk/signer/UportSigner.kt
@@ -379,7 +379,7 @@ open class UportSigner {
 
         data class EncryptionCombo(val keyProtection: KeyProtection, val encPayload: String, val err: Exception?)
 
-        internal val EMPTY_SIGNATURE_DATA = SignatureData(BigInteger.ZERO, BigInteger.ZERO, 0)
+        internal val EMPTY_SIGNATURE_DATA = SignatureData(BigInteger.ZERO, BigInteger.ZERO, BigInteger.ZERO)
 
     }
 

--- a/signer/src/test/java/com/uport/sdk/signer/crypto/bip32/DerivationTest.kt
+++ b/signer/src/test/java/com/uport/sdk/signer/crypto/bip32/DerivationTest.kt
@@ -3,10 +3,8 @@ package com.uport.sdk.signer.crypto.bip32
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.kethereum.bip32.model.Seed
-import org.kethereum.bip32.model.XPriv
-import org.kethereum.bip32.toExtendedKey
 import org.kethereum.bip32.toKey
-import org.walleth.khex.hexToByteArray
+import org.komputing.khex.extensions.hexToByteArray
 
 class DerivationTest {
 
@@ -18,14 +16,11 @@ class DerivationTest {
 
             val derivedKey = Seed(it.seed.hexToByteArray()).toKey(it.path)
 
-            val obtainedPub = derivedKey.asPublicOnly().serialize()
+            val obtainedPub = derivedKey.serialize(publicKeyOnly = true)
             assertEquals(it.expectedPublicKey, obtainedPub)
 
             val obtainedPrv = derivedKey.serialize()
             assertEquals(it.expectedPrivateKey, obtainedPrv)
-
-            assertEquals(XPriv(it.expectedPublicKey).toExtendedKey(), derivedKey.asPublicOnly())
-            assertEquals(XPriv(it.expectedPrivateKey).toExtendedKey(), derivedKey)
 
             counter++
 

--- a/signer/src/test/java/com/uport/sdk/signer/crypto/bip39/MnemonicTest.kt
+++ b/signer/src/test/java/com/uport/sdk/signer/crypto/bip39/MnemonicTest.kt
@@ -14,8 +14,8 @@ import org.kethereum.bip39.toKey
 import org.kethereum.bip39.toSeed
 import org.kethereum.bip39.validate
 import org.kethereum.bip39.wordlists.WORDLIST_ENGLISH
+import org.komputing.khex.extensions.hexToByteArray
 import org.spongycastle.jce.provider.BouncyCastleProvider
-import org.walleth.khex.hexToByteArray
 import java.security.Security
 
 /**


### PR DESCRIPTION
This PR updates kethereum to 0.76.1 and the kotlin-common libs to 0.3.0
Because of downstream breaking changes, some dependency have to be explicitly declared now and some imports had to be adapted.

No functionality change was made, all tests were kept (with APIs adapted)